### PR TITLE
fixed: percent field displayed as code insted of widget

### DIFF
--- a/dbsettings/values.py
+++ b/dbsettings/values.py
@@ -173,7 +173,9 @@ class PercentValue(Value):
                 # Place a percent sign after a smaller text field
                 attrs = kwargs.pop('attrs', {})
                 attrs['size'] = attrs['max_length'] = 6
-                return forms.TextInput.render(self, attrs=attrs, *args, **kwargs) + '%'
+                return mark_safe(
+                    forms.TextInput.render(self, attrs=attrs, *args, **kwargs) +
+                    '<span style="vertical-align: middle;">&nbsp;%</span>')
 
     def to_python(self, value):
         return Decimal(value) / 100


### PR DESCRIPTION
Hello, i tried to use PercentField and found that it displays as code instead of input. So i fixed this by adding mark_safe to widget function.

also i added vertical-align to percent sign and a space between widget and sign, so it looks better now.
